### PR TITLE
Enabled attaching of the editor (for direct access) to any part of the scope hierarchy

### DIFF
--- a/test/ace.spec.js
+++ b/test/ace.spec.js
@@ -31,19 +31,19 @@ describe('uiAce', function () {
 			}
 			expect(compile).not.toThrow();
 		});
-		
+
 		it('should be wrapped with .ace_editor_wrapper', function () {
 			var element = $compile('<div ui-ace>')(scope);
 			expect(element.parent().hasClass('ace_editor_wrapper')).toBeTruthy();
 		});
 
-		
+
 		it('should watch the uiAce attribute', function () {
 			spyOn(scope, '$watch');
 			$compile('<div ui-ace ng-model="foo">')(scope);
 			expect(scope.$watch).toHaveBeenCalled();
 		});
-		
+
 	});
 
 	describe('instance', function () {
@@ -132,6 +132,8 @@ describe('uiAce', function () {
       it('should access to this instance in the scope', function () {
         $compile('<div ui-ace scope-instance="foo">')(scope);
         expect(scope.foo).toBe(_ace);
+        $compile('<div ui-ace scope-instance="bar.baz.qux">')(scope);
+        expect(scope.bar.baz.qux).toBe(_ace);
       });
     });
 	});
@@ -155,5 +157,5 @@ describe('uiAce', function () {
 		});
 	});
 
-	
+
 });

--- a/ui-ace.js
+++ b/ui-ace.js
@@ -96,11 +96,17 @@ angular.module('ui.ace', [])
         // EVENTS
         session.on('change', onChange(opts.onChange));
 
-        // Direct instance access
+        // Allow the editor to be directly accessed via the location in the scope specified by the scope-instance attribute
         if (attrs.scopeInstance && "" !== attrs.scopeInstance) {
-          scope[attrs.scopeInstance] = acee;
+          var parts, last_part, loc, i;
+          parts = attrs.scopeInstance.split(".");
+          last_part = parts.pop();
+          loc = scope;
+          for (i = 0; i < parts.length; i++) {
+            loc = loc[parts[i]] = (loc[parts[i]] || {});
+          }
+          loc[last_part] = acee;
         }
-
       }
     };
   }]);


### PR DESCRIPTION
This commit allows for the editor object to be attached anywhere within the scope, as is usually the case when referencing models etc from attributes.

So for example `scope-instance="foo.bar.baz"` and `scope-instance="$parent.foo"` should now work as expected.

I extended the relevant spec to test for such a case.
