### PR TITLE
Watch Handler Gets Called Twice

### DIFF
--- a/src/ui-ace.js
+++ b/src/ui-ace.js
@@ -229,7 +229,8 @@ angular.module('ui.ace', [])
         setOptions(acee, session, opts);
 
         // Listen for option updates
-        scope.$watch( attrs.uiAce, function() {
+        scope.$watch( attrs.uiAce, function(current, previous) {
+          if (current === previous) return;
           opts = angular.extend({}, options, scope.$eval(attrs.uiAce));
 
           // unbind old change listener


### PR DESCRIPTION
Watch handler is called twice this causes onload to get called twice which can cause problems.  According to https://docs.angularjs.org/api/ng/type/$rootScope.Scope#methods_$watch we can add a check to only handle changes.

Added check to watch of attrs.uiAce so that the handler only gets called when something actually changes
