### PR TITLE
feat(directive): worker path for concatenated and minified configuration...

### DIFF
--- a/src/ui-ace.js
+++ b/src/ui-ace.js
@@ -29,6 +29,13 @@ angular.module('ui.ace', [])
      * @param {object} opts Options to be set
      */
     var setOptions = function(acee, session, opts) {
+
+      // sets the ace worker path, if running from concatenated
+      // or minified source
+      if (angular.isDefined(opts.workerPath)) {
+        var config = window.ace.require('ace/config');
+        config.set('workerPath', opts.workerPath);
+      }
       // ace requires loading
       if (angular.isDefined(opts.require)) {
         opts.require.forEach(function (n) {

--- a/test/ace.spec.js
+++ b/test/ace.spec.js
@@ -28,6 +28,52 @@ describe('uiAce', function () {
       _ace = window.ace;
       spyOn(window.ace, 'require');
     });
+    it('should not call ace/config if a workerPath is not defined', function () {
+      $compile('<div ui-ace>')(scope);
+      expect(_ace.require).not.toHaveBeenCalledWith('ace/config');
+    });
+  });
+
+  describe('behavior', function () {
+    var _ace, _config;
+
+    beforeEach(function () {
+      _ace = window.ace;
+      _config = {
+        set: function() { return true; }
+      };
+      spyOn(window.ace, 'require').andReturn(_config);
+    });
+    it('should call ace/config if a workerPath is defined', function () {
+      $compile('<div ui-ace=\'{ workerPath: "/path/to/ace" }\'>')(scope);
+      expect(_ace.require).toHaveBeenCalledWith('ace/config');
+    });
+  });
+
+  describe('behavior', function () {
+    var _ace, _config;
+
+    beforeEach(function () {
+      _ace = window.ace;
+      _config = {
+        set: function() { return true; }
+      };
+      spyOn(window.ace, 'require').andReturn(_config);
+      spyOn(_config, 'set');
+    });
+    it('should call "set" if workerPath is defined', function () {
+      $compile('<div ui-ace=\'{ workerPath: "/path/to/ace" }\'>')(scope);
+      expect(_config.set).toHaveBeenCalled();
+    });
+  });
+
+  describe('behavior', function () {
+    var _ace;
+
+    beforeEach(function () {
+      _ace = window.ace;
+      spyOn(window.ace, 'require');
+    });
     it('should not call window.ace.require if there is no "require" option', function () {
       $compile('<div ui-ace>')(scope);
       expect(_ace.require).not.toHaveBeenCalled();


### PR DESCRIPTION
feat(directive): worker path for concatenated and minified configurations

add "workerPath" option to the directive so that ace can be run even if the files are concatenated, since the concatenation process would cause the workerPath to return a 404 otherwise.

This is useful if you want to minify and concatenate the source, because doing so causes the worker path to return a 404. It is used like this;

```
<div ng-model="Model.Scripting"
     ui-ace="{
        useWrapMode: true,
        showGutter: true,
        theme: 'chrome',
        mode: 'javascript',
        workerPath: '/application/assets/scripts/ace'
    }">
</div>
```
