### PR TITLE
Features/provide custom ace function

### DIFF
--- a/src/ui-ace.js
+++ b/src/ui-ace.js
@@ -7,10 +7,6 @@ angular.module('ui.ace', [])
   .constant('uiAceConfig', {})
   .directive('uiAce', ['uiAceConfig', function (uiAceConfig) {
 
-    if (angular.isUndefined(window.ace)) {
-      throw new Error('ui-ace need ace to work... (o rly?)');
-    }
-
     /**
      * Sets editor options such as the wrapping mode or the syntax checker.
      *
@@ -101,6 +97,10 @@ angular.module('ui.ace', [])
          * @type object
          */
         var ace = opts.ace || window.ace;
+
+        if (!ace) {
+          throw new Error('ui-ace need ace to work... (o rly?)');
+        }
 
         /**
          * ACE editor


### PR DESCRIPTION
(edit: re-submit PR because my previous one was done on the wrong branch and was based on now out-dated code)

Hi there,

First of all, thank you for taking the time to write this Angular+Ace integration directive.

I'm currently using it with a popup window in which I inject my own Angular template and scope.
That allows me to have an app that opens popup windows and still has the ability to use 2-way bindings with them.

So here's how I'm doing it:
1. Include ace.js in the popup so that it can inject its own css/js properly
2. Use the uiAce directive to show an ACE editor instance inside an angular template (+scope) that is injected in a popup window
3. Modify the ui-ace.js code to allow using a custom `ace` function instead of the one in `window.ace`.
   This is because my ui-ace.js file was loaded from the main app's window (not the popup).
4. When providing the config options to `uiAce`, I provide the `popupWindow.ace` function - which is the `ace` function from the popup's `window` object.

And it seems to work fine. :-)

So if you're interested, here's a pull request to add it to your arsenal.

Cheers,

David
