### PR TITLE
Add ability to modify ace editor renderer options

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ This will copy the UI.Ace files into a `bower_components` folder, along with its
 }"></div>
 ```
 
+To include options applicable to the ACE renderer, you can use the `rendererOptions` key:
+
+```html
+<div ui-ace="{
+  rendererOptions: {
+      maxLinks: Infinity
+  }
+}"></div>
+```
+
 ### Working with ng-model
 
 The ui-ace directive plays nicely with ng-model.

--- a/src/ui-ace.js
+++ b/src/ui-ace.js
@@ -91,12 +91,23 @@ angular.module('ui.ace', [])
       }
 
       // advanced options
+      var key, obj;
       if (angular.isDefined(opts.advanced)) {
-          for (var key in opts.advanced) {
+          for (key in opts.advanced) {
               // create a javascript object with the key and value
-              var obj = { name: key, value: opts.advanced[key] };
+              obj = { name: key, value: opts.advanced[key] };
               // try to assign the option to the ace editor
               acee.setOption(obj.name, obj.value);
+          }
+      }
+
+      // advanced options for the renderer
+      if (angular.isDefined(opts.rendererOptions)) {
+          for (key in opts.rendererOptions) {
+              // create a javascript object with the key and value
+              obj = { name: key, value: opts.rendererOptions[key] };
+              // try to assign the option to the ace editor
+              acee.renderer.setOption(obj.name, obj.value);
           }
       }
     };


### PR DESCRIPTION
We had a need to set the minLines and maxLines options of the ACE renderer and have been working off the patch below.

The weird placement of the var statement is because of the jslinter that complained about redefining the variable.

I'm not sure how you want this pull request formatted.  Below are the changes for master, do you take care of managing the bower branch?  I noticed that the current bower branch is not up-to-date with the current master branch.

@pdemello