### PR TITLE
align boolean checking with Angular

### DIFF
--- a/src/ui-ace.js
+++ b/src/ui-ace.js
@@ -254,7 +254,7 @@ angular.module('ui.ace', [])
         };
 
         attrs.$observe('readonly', function (value) {
-          acee.setReadOnly(!!value || value === '');
+          acee.setReadOnly(!!value);
         });
 
         // Value Blind


### PR DESCRIPTION
As we know in Angular built-in directives [ngIf](https://github.com/angular/angular.js/blob/master/src/ng/directive/ngIf.js) and [ngShowHide](https://github.com/angular/angular.js/blob/master/src/ng/directive/ngShowHide.js), they simply use `if` expression to check boolean like below:

```
$scope.$watch($attr.ngIf, function ngIfWatchAction(value) {
    if (value) {
    }
    else {
    }
```

in which case, `''` would be regarded as FALSE. As ui-ace is yet another Angular directive, users are likely to think the behavior in `<ui-ace readonly=""">` is totally the same as `<div ng-if=""></div>`. But for now it's not, we would treat empty string as TRUE.

I suppose we can just use `!!value` to check boolean.