### PR TITLE
Change to evalAsync

### DIFF
--- a/src/ui-ace.js
+++ b/src/ui-ace.js
@@ -229,7 +229,7 @@ angular.module('ui.ace', [])
                   // digest loop 'cause ACE is actually using this callback
                   // for any text transformation !
                   !scope.$$phase && !scope.$root.$$phase) {
-                scope.$applyAsync(function () {
+                scope.$evalAsync(function () {
                   ngModel.$setViewValue(newValue);
                 });
               }


### PR DESCRIPTION
A previous commit only fixes part of the problem with Angular 1.2.x compatibility:
https://github.com/angular-ui/ui-ace/commit/9b5d5aaf7dd223f39a8595e54a96e769c9a381e6

There's another instance of applyAsync which should be changed to evalAsync to fix ng-model binding with Angular 1.2.x.