### PR TITLE
add a line to remove ace warning

### DIFF
--- a/src/ui-ace.js
+++ b/src/ui-ace.js
@@ -146,6 +146,7 @@ angular.module('ui.ace', [])
          * @type object
          */
         var acee = window.ace.edit(elm[0]);
+        acee.$blockScrolling = Infinity;
 
         /**
          * ACE editor session.


### PR DESCRIPTION
Fix for Issue#104

Javascript console is currently flooded with this message

```
Automatically scrolling cursor into view after selection change this will be disabled in the next version set editor.$blockScrolling = Infinity to disable this message
```

Adding the line below remove the message

```
acee.$blockScrolling = Infinity;
```
