### PR TITLE
Options not applied within transcluded directive

### DIFF
--- a/src/ui-ace.js
+++ b/src/ui-ace.js
@@ -275,9 +275,8 @@ angular.module('ui.ace', [])
         }
 
         // Listen for option updates
-        var updateOptions = function (current, previous) {
-          if (current === previous) return;
-          opts = angular.extend({}, options, scope.$eval(attrs.uiAce));
+        var updateOptions = function (newOptions) {
+          opts = angular.extend({}, options, newOptions);
 
           opts.callbacks = [ opts.onLoad ];
           if (opts.onLoad !== options.onLoad) {

--- a/src/ui-ace.js
+++ b/src/ui-ace.js
@@ -309,7 +309,7 @@ angular.module('ui.ace', [])
 
         // set the options here, even if we try to watch later, if this
         // line is missing things go wrong (and the tests will also fail)
-        updateOptions(options);
+        updateOptions(opts);
 
         elm.on('$destroy', function () {
           acee.session.$stopWorker();


### PR DESCRIPTION
I came across an issue where a wrapping directive within a transcluded directive would not be able to set `ui-ace` options. After stepping through the code, I found out the following:

When `uiAce.link()` is executing, the value of `scope.$eval(attrs.uiAce)` was `undefined`. However, when the `scope.$watch(attrs.uiAce)` was executed for the first time, the value was properly set to the expected object. However, https://github.com/angular-ui/ui-ace/blob/4ce0309c5de4e68c1a28643576d8f10ec93960e0/src/ui-ace.js#L279 short-circuits that first trigger of `$watch`, leaving us just the default options.

The proposed fix removes that short-circuit (which was not a performance issue in my testing). It also fixes the first call of `updateOptions`, which erroneously used `options` instead of `opts`. 

By the way, in my testing, the directive wroks as expected without that `updateOptions` call when the short-circuit is removed. However, the tests fail. It seems like the tests are in the wrong here - they should probably wait a digest cycle before doing their assertions on the Ace Editor options.
