### PR TITLE
enable the load ui-ace as a commonjs module

### DIFF
--- a/src/ui-ace.js
+++ b/src/ui-ace.js
@@ -1,4 +1,16 @@
+/* */ 
+'format global';
+'deps angular';
+/*global module, exports*/
+/*jshint globalstrict:true*/
 'use strict';
+
+/* commonjs package manager support (eg componentjs) */
+if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.exports === exports){
+  module.exports = 'ui.ace';
+}
+
+(function (window, angular, undefined) {
 
 /**
  * Binds a ACE Editor widget
@@ -326,3 +338,4 @@ angular.module('ui.ace', [])
       }
     };
   }]);
+})(window, window.angular);


### PR DESCRIPTION
Hi, 

Currently, the ui-ace.js do not works when using es6 module with jspm for instance. Angular dependency is not exposed and the module name is not exported.

This PR is fixing it
