### PR TITLE
Remove suggestions popup on destroy

### DIFF
--- a/src/ui-ace.js
+++ b/src/ui-ace.js
@@ -314,6 +314,9 @@ angular.module('ui.ace', [])
         elm.on('$destroy', function () {
           acee.session.$stopWorker();
           acee.destroy();
+          if (acee.completer && acee.completer.popup) {
+            acee.completer.popup.container.remove();
+          }
         });
 
         scope.$watch(function() {


### PR DESCRIPTION
Testing for this winds up being somewhat painful, because the popup doesn't exist until somebody types something. This is way beyond the scope of the current ace-ui test suite.
