### PR TITLE
Fix workerPath bug - update to ACE api...

### DIFF
--- a/src/ui-ace.js
+++ b/src/ui-ace.js
@@ -34,7 +34,7 @@ angular.module('ui.ace', [])
       // or minified source
       if (angular.isDefined(opts.workerPath)) {
         var config = window.ace.require('ace/config');
-        config.set('workerPath', opts.workerPath);
+        config.set('basePath', opts.workerPath);
       }
       // ace requires loading
       if (angular.isDefined(opts.require)) {


### PR DESCRIPTION
workerPath name in ace API is now basePath, causing your version to not accept workerPath any longer, so couldn't load assets because it couldn't find the folder in bower_components...
