### PR TITLE
Unnecessary object creation.

### DIFF
--- a/src/ui-ace.js
+++ b/src/ui-ace.js
@@ -96,23 +96,19 @@ angular.module('ui.ace', [])
       }
 
       // advanced options
-      var key, obj;
+      var key;
       if (angular.isDefined(opts.advanced)) {
           for (key in opts.advanced) {
-              // create a javascript object with the key and value
-              obj = { name: key, value: opts.advanced[key] };
               // try to assign the option to the ace editor
-              acee.setOption(obj.name, obj.value);
+              acee.setOption(key, opts.advanced[key]);
           }
       }
 
       // advanced options for the renderer
       if (angular.isDefined(opts.rendererOptions)) {
           for (key in opts.rendererOptions) {
-              // create a javascript object with the key and value
-              obj = { name: key, value: opts.rendererOptions[key] };
               // try to assign the option to the ace editor
-              acee.renderer.setOption(obj.name, obj.value);
+              acee.renderer.setOption(key, opts.rendererOptions[key]);
           }
       }
 


### PR DESCRIPTION
Looks like `obj` is not used elsewhere, we can apply values directly
into `session.setOption()`.
