### PR TITLE
advanced editor mode configuration

### DIFF
--- a/src/ui-ace.js
+++ b/src/ui-ace.js
@@ -86,6 +86,9 @@ angular.module('ui.ace', [])
       if (angular.isString(opts.mode)) {
         session.setMode('ace/mode/' + opts.mode);
       }
+      else if(angular.isObject(opts.mode)) {
+        session.setMode( opts.mode );
+      }
       // Advanced options
       if (angular.isDefined(opts.firstLineNumber)) {
         if (angular.isNumber(opts.firstLineNumber)) {


### PR DESCRIPTION
some editor modes allow extended options, e.g. inline:true for php mode
( https://github.com/ajaxorg/ace/issues/2542 )
It can be configured this way:

``` html
<div ui-ace="{ mode: {path:'ace/mode/php',inline:true} }"></div>
```

although setMode() is still undocumented, this should work for all other possible options, too.
