### PR TITLE
Hide autocomplete when editor is deleted

### DIFF
--- a/src/ui-ace.js
+++ b/src/ui-ace.js
@@ -313,6 +313,8 @@ angular.module('ui.ace', [])
 
         elm.on('$destroy', function () {
           acee.session.$stopWorker();
+          if (angular.isObject(acee.completer))
+                acee.completer.detach();
           acee.destroy();
         });
 


### PR DESCRIPTION
Currently popup is still visible on a screen, but editor itself gets deleted